### PR TITLE
zenn-embed-contentを有効にした

### DIFF
--- a/_posts/shell-in-rust.md
+++ b/_posts/shell-in-rust.md
@@ -12,9 +12,9 @@ date: "2021.09.02"
 
 今回実装するシェルは`coconush🥥`と名付けました。錆(Rust)は基本的に茶色い見た目をしています。そんな Rust で、カーネルを守る貝殻(シェル)を実装するので、同じく「茶色の見た目で、何かを覆うもの」としてココナッツから名前を取りました ~~Nushell 被り~~ 。GitHub のリポジトリと Zenn のスクラップを載せておきます。
 
-[oshanQQ/coconush: 🥥 A toy shell implemented in Rust](https://github.com/oshanQQ/coconush)
+https://github.com/oshanQQ/coconush
 
-[自作シェルを Rust で実装するときのメモ](https://zenn.dev/oshanqq/scraps/9af8e5c9fa054c)
+https://zenn.dev/oshanqq/scraps/9af8e5c9fa054c
 
 # 実装
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "remark": "14.0.2",
         "remark-html": "15.0.1",
         "typescript": "^4.2.4",
-        "zenn-content-css": "^0.1.95",
-        "zenn-embed-elements": "^0.1.110",
-        "zenn-markdown-html": "^0.1.95"
+        "zenn-content-css": "0.1.106",
+        "zenn-embed-elements": "0.1.106",
+        "zenn-markdown-html": "0.1.106"
       },
       "devDependencies": {
         "@types/jest": "^26.0.23",
@@ -3073,19 +3073,19 @@
       }
     },
     "node_modules/zenn-content-css": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-content-css/-/zenn-content-css-0.1.110.tgz",
-      "integrity": "sha512-zPdxEufKbHDVv2o9AoP5Rc4KGiOtFie2IQsgQ5R3VcYnXYD9aK/gL6EMXP3wSMB9kJJrXM/L6qAjosn7wtbnUA=="
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-content-css/-/zenn-content-css-0.1.106.tgz",
+      "integrity": "sha512-nzr53leHlPiLnhApqeJzOVQ326ogVKA+1+OV4BXNURDeTmIULDytn8TtWu3wxJy1bb3JpFxHnihBuxGtiCCSQA=="
     },
     "node_modules/zenn-embed-elements": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-embed-elements/-/zenn-embed-elements-0.1.110.tgz",
-      "integrity": "sha512-gn1LFWM4deMDCwDuKNcThxV+SR4A30yB4/3gkLyBwo4FhOuDEvC2KKJchXlHlFr4BVHVNPoC0KGqXy2QsC0bvg=="
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-embed-elements/-/zenn-embed-elements-0.1.106.tgz",
+      "integrity": "sha512-+THhETIRxLhDUCREyX1eWafpPGX6VFQ1VV4hON7fS7pSa0kjykRwGCE2lz9KkwqgrM9UUXPyO6JSBTDrJtBWEQ=="
     },
     "node_modules/zenn-markdown-html": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-markdown-html/-/zenn-markdown-html-0.1.110.tgz",
-      "integrity": "sha512-C0VVqg+chQKZgg2+rduPohVY+8KBoGFwq2szN7AhfWNBXI8Qi6KuxljN+wBXCjTcFpZewPf3k9HlF0NwtDaq0w==",
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-markdown-html/-/zenn-markdown-html-0.1.106.tgz",
+      "integrity": "sha512-jsR3O4MX3IorzjrMZFF731nmFPy8T+chX2qwhXA6IOcf7j7+1dl1+ccvpxtnredd6Ztb7B0M2wUpvTgWDF+xyQ==",
       "dependencies": {
         "@steelydylan/markdown-it-imsize": "^1.0.2",
         "markdown-it": "^12.3.2",
@@ -3095,7 +3095,7 @@
         "markdown-it-inline-comments": "^1.0.1",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-task-lists": "^2.1.1",
-        "prismjs": "^1.27.0"
+        "prismjs": "^1.26.0"
       }
     },
     "node_modules/zwitch": {
@@ -5136,19 +5136,19 @@
       "dev": true
     },
     "zenn-content-css": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-content-css/-/zenn-content-css-0.1.110.tgz",
-      "integrity": "sha512-zPdxEufKbHDVv2o9AoP5Rc4KGiOtFie2IQsgQ5R3VcYnXYD9aK/gL6EMXP3wSMB9kJJrXM/L6qAjosn7wtbnUA=="
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-content-css/-/zenn-content-css-0.1.106.tgz",
+      "integrity": "sha512-nzr53leHlPiLnhApqeJzOVQ326ogVKA+1+OV4BXNURDeTmIULDytn8TtWu3wxJy1bb3JpFxHnihBuxGtiCCSQA=="
     },
     "zenn-embed-elements": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-embed-elements/-/zenn-embed-elements-0.1.110.tgz",
-      "integrity": "sha512-gn1LFWM4deMDCwDuKNcThxV+SR4A30yB4/3gkLyBwo4FhOuDEvC2KKJchXlHlFr4BVHVNPoC0KGqXy2QsC0bvg=="
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-embed-elements/-/zenn-embed-elements-0.1.106.tgz",
+      "integrity": "sha512-+THhETIRxLhDUCREyX1eWafpPGX6VFQ1VV4hON7fS7pSa0kjykRwGCE2lz9KkwqgrM9UUXPyO6JSBTDrJtBWEQ=="
     },
     "zenn-markdown-html": {
-      "version": "0.1.110",
-      "resolved": "https://registry.npmjs.org/zenn-markdown-html/-/zenn-markdown-html-0.1.110.tgz",
-      "integrity": "sha512-C0VVqg+chQKZgg2+rduPohVY+8KBoGFwq2szN7AhfWNBXI8Qi6KuxljN+wBXCjTcFpZewPf3k9HlF0NwtDaq0w==",
+      "version": "0.1.106",
+      "resolved": "https://registry.npmjs.org/zenn-markdown-html/-/zenn-markdown-html-0.1.106.tgz",
+      "integrity": "sha512-jsR3O4MX3IorzjrMZFF731nmFPy8T+chX2qwhXA6IOcf7j7+1dl1+ccvpxtnredd6Ztb7B0M2wUpvTgWDF+xyQ==",
       "requires": {
         "@steelydylan/markdown-it-imsize": "^1.0.2",
         "markdown-it": "^12.3.2",
@@ -5158,7 +5158,7 @@
         "markdown-it-inline-comments": "^1.0.1",
         "markdown-it-link-attributes": "^3.0.0",
         "markdown-it-task-lists": "^2.1.1",
-        "prismjs": "^1.27.0"
+        "prismjs": "^1.26.0"
       }
     },
     "zwitch": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "remark": "14.0.2",
     "remark-html": "15.0.1",
     "typescript": "^4.2.4",
-    "zenn-content-css": "^0.1.95",
-    "zenn-embed-elements": "^0.1.110",
-    "zenn-markdown-html": "^0.1.95"
+    "zenn-content-css": "0.1.106",
+    "zenn-embed-elements": "0.1.106",
+    "zenn-markdown-html": "0.1.106"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { AppProps } from "next/app";
 import "../styles/index.css";
 import { useEffect } from "react";
+import initTwitterScriptInner from "zenn-embed-elements/lib/init-twitter-script-inner";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -8,6 +9,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }, []);
   return (
     <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: initTwitterScriptInner,
+        }}
+      />
       <Component {...pageProps} />
     </>
   );


### PR DESCRIPTION
# やったこと
- `zenn-embed-content`のバージョンを`0.1.106`に下げた
- `package.json`のバージョン表記の先頭の`^`を消した

close #6